### PR TITLE
Add Deepnote launch button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Python-programming-exercises
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/darkprinx/100-plus-Python-programming-exercises-extended/master?filepath=notebooks%2F)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/darkprinx/100-plus-Python-programming-exercises-extended/master?filepath=notebooks%2F)<br>
+[![Deepnote](https://deepnote.com/buttons/try-in-a-jupyter-notebook.svg
+)](https://deepnote.com/launch?url=https%3A%2F%2Fgithub.com%2Fdarkprinx%2F100-plus-Python-programming-exercises-extended%2Fblob%2Fmaster%2Fnotebooks%2FDay_01.ipynb)
+
 ---------------------
 ##	Introduction 
 


### PR DESCRIPTION
Hi there, I'm Dan from Deepnote. We're a small startup creating a better data science notebook compatible with Jupyter and one of the things we're really interested is making it easier for people to try and learn from existing projects.
I was trying out Deepnote with some interesting public repos, including yours and since I already set it up for myself, I thought it might be useful for others too to have a one-click button to run your repo, so I submitted a PR. Compared to binder, Deepnote offers more advanced features like collaboration or persistent environment so people can save their progress and come back to it later.

Hope you find it useful, and thanks for your work!